### PR TITLE
Use `condaforge/miniforge3` as base image to build Hystmag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Create a base image
-FROM continuumio/miniconda3 AS base
+FROM condaforge/miniforge3 AS base
 COPY ./patches/escript.yaml ./escript.yaml
 RUN conda env create -f ./escript.yaml
 


### PR DESCRIPTION
This is due to the change in the `conda` license.

Fixes MaMMoS-project/management#49