### PR TITLE
adapt requests to documented automatic retries example

### DIFF
--- a/changes/67.fixed.md
+++ b/changes/67.fixed.md
@@ -1,1 +1,0 @@
-Mesh download tries for up to 3 times with 5 second delay until an HTTP status code 200 is returned by the request. If such status code is not returned, an error is raised.

--- a/changes/70.changed.md
+++ b/changes/70.changed.md
@@ -1,0 +1,1 @@
+Implement automatic retries to download meshes if the requests fail. The requests will try three times in total, with a backoff factor of 0.1.

--- a/src/mammos_mumag/mesh.py
+++ b/src/mammos_mumag/mesh.py
@@ -3,9 +3,9 @@
 import json
 import pathlib
 import shutil
-import time
 
 import requests
+import urllib3
 
 
 def get_mesh_json():
@@ -81,13 +81,14 @@ class Mesh:
         if self._local:
             shutil.copy(self._path, dest)
         else:
-            for _ in range(3):
-                res = requests.get(self._url)
-                if res.status_code == 200:
-                    break
-                time.sleep(5)
-            else:
-                raise RuntimeError(f"Failed 3 requests. Error code: {res.status_code}")
+            s = requests.Session()
+            retries = urllib3.util.Retry(
+                total=3,
+                backoff_factor=0.1,
+                status_forcelist=[500, 502, 503, 504],
+            )
+            s.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+            res = s.get(self._url)
             with open(dest, "wb") as f:
                 f.write(res.content)
 
@@ -106,12 +107,13 @@ class Mesh:
         else:
             keeper_url = get_mesh_json()["metadata"]["keeper_url"]
             mesh_url = f"{keeper_url}files/?p=/{self.name}/mesh{dest.suffix}&dl=1"
-            for _ in range(3):
-                res = requests.get(mesh_url)
-                if res.status_code == 200:
-                    break
-                time.sleep(5)
-            else:
-                raise RuntimeError(f"Failed 3 requests. Error code: {res.status_code}")
+            s = requests.Session()
+            retries = urllib3.util.Retry(
+                total=3,
+                backoff_factor=0.1,
+                status_forcelist=[500, 502, 503, 504],
+            )
+            s.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+            res = s.get(mesh_url)
             with open(dest, "wb") as f:
                 f.write(res.content)


### PR DESCRIPTION
I have used [this example](https://docs.python-requests.org/en/latest/user/advanced/#example-automatic-retries) to follow the standard use of `requests`.