### PR TITLE
Remove some cell output in hysteresis multigrain

### DIFF
--- a/changes/95.misc.md
+++ b/changes/95.misc.md
@@ -1,0 +1,1 @@
+Remove cell output for multigrain simulations in static HTML.

--- a/examples/multigrain-simulation.ipynb
+++ b/examples/multigrain-simulation.ipynb
@@ -120,6 +120,9 @@
    "execution_count": 5,
    "id": "382ac95d-6386-48a2-bce4-335bbe685a8a",
    "metadata": {
+    "mystnb": {
+     "remove_code_outputs": true
+    },
     "scrolled": true
    },
    "outputs": [
@@ -2523,6 +2526,9 @@
    "execution_count": 10,
    "id": "6223142b-447d-494c-954d-aa08bf654d87",
    "metadata": {
+    "mystnb": {
+     "remove_code_outputs": true
+    },
     "scrolled": true
    },
    "outputs": [
@@ -4229,7 +4235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
The simulation prints a lot of internal status information, which makes the page extremely long and difficult to read.